### PR TITLE
needed a version this way to resolve

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,13 +30,13 @@
     "test": "grunt travis --verbose"
   },
   "peerDependencies": {
-    "flex-sdk": "*"
+    "flex-sdk": "^4.6.0-0"
   },
   "dependencies": {
     "async": "^0.9.0"
   },
   "devDependencies": {
-    "flex-sdk": "*",
+    "flex-sdk": "^4.6.0-0",
     "grunt": "^0.4.5",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-jshint": "^0.10.0",


### PR DESCRIPTION
tested out node v6.0 and needed to roll my system back. The recommended way was to flush my `node_modules` as well as uninstalling npm and node. 

I did a fresh install of node v4.4.3 which came with npm 2.15.1.

After trying to reinstall the project, the `flex-sdk` peerDependency would not resolve without specifying a more specific version syntax vs. the wildcard.

Maybe keep this around for a future merge if this rises its head again...
